### PR TITLE
only use get_langauge() for more consistency

### DIFF
--- a/textblocks/templatetags/textblock_tags.py
+++ b/textblocks/templatetags/textblock_tags.py
@@ -13,18 +13,12 @@ from textblocks import conf
 register = template.Library()
 
 
-@register.simple_tag(takes_context=True)
-def textblock(context, key, type='text/plain', show_key='not_set'):
+@register.simple_tag()
+def textblock(key, type='text/plain', show_key='not_set'):
     if type not in map(lambda x: x[0], TYPE_CHOICES):
         raise template.TemplateSyntaxError('Type does not exist')
 
-    request = context.get('request', None)
-    language_code = None
-    if request:
-        language_code = getattr(request, 'LANGUAGE_CODE', None)
-    if not language_code:
-        language_code = get_language()
-
+    language_code = get_language()
     hash = hashlib.md5(key.encode('utf-8')).hexdigest()
     cache_key = 'textblock_{0}_{1}'.format(language_code, hash)
 


### PR DESCRIPTION
keeping it even simpler ;-)

having a project where I needed to use `django.utils.translations.override` (or the template tag from django-i18next), I came across the fact that the LANGUAGE_CODE from the request object must not always be the language that is currently active. So, we then end up with a cache key with an incorrect lang value in it.

the proposed fix reduces complexity, and doesn't require a context for the tag anymore. it also makes accessing the tag code from python easier, as no more empty {} must be provided as context object.