### PR TITLE
TEXTBLOCKS_SHOWKEY works again. more tests

### DIFF
--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -36,3 +36,9 @@ TEMPLATES = [
         },
     },
 ]
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}

--- a/tests/testapp/test_textblocks.py
+++ b/tests/testapp/test_textblocks.py
@@ -61,14 +61,22 @@ class TextblocksTest(TestCase):
         tb = TextBlock.objects.get()
         # default: show key, with kwargs
         self.assertEqual(
-            textblock('test', show_key=True),
+            textblock('test', show_key="1"),
             'test',
         )
-        # with settings
+        # with settings, showkey enabled
         with self.settings(TEXTBLOCKS_SHOWKEY=True):
             self.assertEqual(
                 textblock('test'),
                 'test',
+            )
+            self.assertEqual(
+                textblock('test', show_key="True"),
+                'test',
+            )
+            self.assertEqual(
+                textblock('test', show_key=0),
+                '',
             )
         tb.delete()
 

--- a/tests/testapp/test_textblocks.py
+++ b/tests/testapp/test_textblocks.py
@@ -78,6 +78,10 @@ class TextblocksTest(TestCase):
                 textblock('test', show_key=0),
                 '',
             )
+            self.assertEqual(
+                textblock('test', show_key=False),
+                '',
+            )
         tb.delete()
 
     def test_tag_caching(self):

--- a/tests/testapp/test_textblocks.py
+++ b/tests/testapp/test_textblocks.py
@@ -92,7 +92,7 @@ class TextblocksTest(TestCase):
                     textblock('test1'),
                     'Just testing',
                 )
-
+            # cache hit!
             with self.assertNumQueries(0):
                 self.assertEqual(
                     textblock('test1'),

--- a/textblocks/conf.py
+++ b/textblocks/conf.py
@@ -5,3 +5,4 @@ from django.conf import settings
 
 
 TEXTBLOCKS_SHOWKEY = getattr(settings, 'TEXTBLOCKS_SHOWKEY', False)
+setattr(settings, 'TEXTBLOCKS_SHOWKEY', TEXTBLOCKS_SHOWKEY)

--- a/textblocks/models.py
+++ b/textblocks/models.py
@@ -8,6 +8,8 @@ from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
+from . import conf  # noqa so it sets defaults on django.conf.settings
+
 
 TYPE_CHOICES = (
     ('text/plain', _('text/plain')),

--- a/textblocks/templatetags/textblock_tags.py
+++ b/textblocks/templatetags/textblock_tags.py
@@ -4,11 +4,12 @@ from __future__ import unicode_literals
 import hashlib
 
 from django import template
+from django.conf import settings
 from django.core.cache import cache
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
 
-from textblocks import conf
+# from textblocks import conf
 from textblocks.models import TYPE_CHOICES, TextBlock
 
 
@@ -35,7 +36,9 @@ def textblock(key, type='text/plain', show_key='not_set'):
 
     text = textblock.content
     if not text:
-        if show_key != 'not_set' and (show_key or conf.TEXTBLOCKS_SHOWKEY):
+        # print (settings.TEXTBLOCKS_SHOWKEY)
+        if (show_key != 'not_set' and show_key) or \
+                (show_key == 'not_set' and settings.TEXTBLOCKS_SHOWKEY):
             text = textblock.key
 
     # Prevent escaping if the type is set to 'text/html'

--- a/textblocks/templatetags/textblock_tags.py
+++ b/textblocks/templatetags/textblock_tags.py
@@ -36,6 +36,7 @@ def textblock(key, type='text/plain', show_key='not_set'):
 
     text = textblock.content
     if not text:
+        # if (show_key==True) or (show_key and settings.TEXTBLOCKS_SHOWKEY):
         if (show_key != 'not_set' and show_key) or \
                 (show_key == 'not_set' and settings.TEXTBLOCKS_SHOWKEY):
             text = textblock.key

--- a/textblocks/templatetags/textblock_tags.py
+++ b/textblocks/templatetags/textblock_tags.py
@@ -36,7 +36,6 @@ def textblock(key, type='text/plain', show_key='not_set'):
 
     text = textblock.content
     if not text:
-        # print (settings.TEXTBLOCKS_SHOWKEY)
         if (show_key != 'not_set' and show_key) or \
                 (show_key == 'not_set' and settings.TEXTBLOCKS_SHOWKEY):
             text = textblock.key

--- a/textblocks/templatetags/textblock_tags.py
+++ b/textblocks/templatetags/textblock_tags.py
@@ -36,7 +36,7 @@ def textblock(key, type='text/plain', show_key='not_set'):
 
     text = textblock.content
     if not text:
-        # if (show_key==True) or (show_key and settings.TEXTBLOCKS_SHOWKEY):
+        # if show_key or (show_key and settings.TEXTBLOCKS_SHOWKEY):
         if (show_key != 'not_set' and show_key) or \
                 (show_key == 'not_set' and settings.TEXTBLOCKS_SHOWKEY):
             text = textblock.key


### PR DESCRIPTION
- re-established the showkey settings/kwargs behaviour.
- refactored tests, no cache by default, explicit cache testing
- refactored conf module, not sure how this is "best practiced"...I normally use django-appconf, but this is a dependency...