### PR TITLE
fix ckeditor widget encoding problems

### DIFF
--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -12,15 +12,26 @@ DATABASES = {
     }
 }
 
+ROOT_URLCONF = 'testapp.urls'
+
 INSTALLED_APPS = [
     'testapp',
     'textblocks',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.messages',
+    'django.contrib.sessions',
+    'django.contrib.staticfiles',
+    'django.contrib.admin',
 ]
 
-BASEDIR = os.path.dirname(__file__)
+STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
 SECRET_KEY = 'supersikret'
-# ROOT_URLCONF = 'testapp.urls'
+
 ALLOWED_HOSTS = ['*']
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -36,6 +47,17 @@ TEMPLATES = [
         },
     },
 ]
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
+)
+
+MIDDLEWARE = MIDDLEWARE_CLASSES
 
 CACHES = {
     'default': {

--- a/tests/testapp/test_admin.py
+++ b/tests/testapp/test_admin.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, unicode_literals
+
+try:
+    reload
+except NameError:
+    from importlib import reload
+
+from django.test import TestCase
+
+from textblocks import conf
+from textblocks.models import TextBlock
+from textblocks.templatetags.textblock_tags import textblock
+
+
+class TextblocksTest(TestCase):
+
+    cache_enabled_settings = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        }
+    }
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_superuser(
+            username='fred',
+            password='test',
+            email='test@test.fred',
+        )
+
+    def tearDown(self):
+        pass
+
+    def test_has_css(self):
+        self.client.login(username='fred', password='test')
+        url = reverse('admin:textblocks_textblock_changelist')
+        response = self.client.get(url, follow=True)
+        self.assertContains(response, 'admin/aasdvadsvasdyle.css')

--- a/tests/testapp/test_admin.py
+++ b/tests/testapp/test_admin.py
@@ -1,15 +1,17 @@
+# encoding: utf-8
 from __future__ import absolute_import, unicode_literals
+
+from django.contrib.auth.models import User
+from django.urls import reverse
 
 try:
     reload
 except NameError:
     from importlib import reload
 
-from django.test import TestCase
+from django.test import TestCase, Client
 
-from textblocks import conf
 from textblocks.models import TextBlock
-from textblocks.templatetags.textblock_tags import textblock
 
 
 class TextblocksTest(TestCase):
@@ -31,8 +33,10 @@ class TextblocksTest(TestCase):
     def tearDown(self):
         pass
 
-    def test_has_css(self):
+    def test_renders_non_ascii_into_ckeditor(self):
         self.client.login(username='fred', password='test')
-        url = reverse('admin:textblocks_textblock_changelist')
+        obj = TextBlock(key='test', content='ö$ä-what', type='text/html', )
+        obj.save()
+        url = reverse('admin:textblocks_textblock_change', args=(obj.id, ))
         response = self.client.get(url, follow=True)
-        self.assertContains(response, 'admin/aasdvadsvasdyle.css')
+        self.assertContains(response, 'ö$ä')

--- a/tests/testapp/test_admin.py
+++ b/tests/testapp/test_admin.py
@@ -3,12 +3,6 @@ from __future__ import absolute_import, unicode_literals
 
 from django.contrib.auth.models import User
 from django.urls import reverse
-
-try:
-    reload
-except NameError:
-    from importlib import reload
-
 from django.test import TestCase, Client
 
 from textblocks.models import TextBlock

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+from django.contrib import admin
+
+
+urlpatterns = [
+    url(r'^admin/', admin.site.urls),
+]

--- a/textblocks/widgets.py
+++ b/textblocks/widgets.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 from django import forms


### PR DESCRIPTION
when somehow there is data entered with non ascii characters into a ckeditor field, the json.dump will not work, in `widget.render()`, and therefore silently drop (not render at all) the complete admin form.

Including basic test.