### PR TITLE
fix for translation state filter, when using language codes with a "-"

### DIFF
--- a/textblocks/admin.py
+++ b/textblocks/admin.py
@@ -34,7 +34,8 @@ class TranslationStateFilter(admin.SimpleListFilter):
                 'MODELTRANSLATION_LANGUAGES',
                 settings.LANGUAGES
             )
-            lang_keys = [lang[0] for lang in langs]
+            # modeltranslation does replace "-" with "_" in language codes
+            lang_keys = [lang[0].replace('-', '_') for lang in langs]
             q_objects = Q()
             if self.value() == 'untranslated':
                 for lang_key in lang_keys:


### PR DESCRIPTION
simple fix.

we should add tests for the various modeltranslation issues that could arise, should we? currently, all tests are running without modeltranslation at all, is this correct?